### PR TITLE
CVE-2018-1000210

### DIFF
--- a/Sieve.HR.csproj
+++ b/Sieve.HR.csproj
@@ -23,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.11" />
+    <PackageReference Include="yamldotnet" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

This PR updates the YamlDotNet package to version 5.0.0 to address the IDOR vulnerability identified in CVE-2018-1000210.

Files changed:
- Sieve.HR.csproj

Code changes:
- <PackageReference Include="yamldotnet" Version="4.0.0" />
+ <PackageReference Include="yamldotnet" Version="5.0.0" />

> [!NOTE]
> These are the notes.
				